### PR TITLE
Delete project_info, donor_cases and qcables

### DIFF
--- a/sampuru-server/src/db/V1__create_schema.sql
+++ b/sampuru-server/src/db/V1__create_schema.sql
@@ -50,12 +50,12 @@ CREATE TABLE project_info_item (
     expected integer,
     received integer);
  
-ALTER TABLE donor_case ADD CONSTRAINT case_project_id_match FOREIGN KEY (project_id) REFERENCES project (id);
-ALTER TABLE qcable ADD CONSTRAINT qcable_project_id_match FOREIGN KEY (project_id) REFERENCES project (id);
-ALTER TABLE qcable ADD CONSTRAINT qcable_case_id_match FOREIGN KEY (case_id) REFERENCES donor_case (id);
+ALTER TABLE donor_case ADD CONSTRAINT case_project_id_match FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE;
+ALTER TABLE qcable ADD CONSTRAINT qcable_project_id_match FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE;
+ALTER TABLE qcable ADD CONSTRAINT qcable_case_id_match FOREIGN KEY (case_id) REFERENCES donor_case (id) ON DELETE CASCADE;
 ALTER TABLE deliverable_file ADD CONSTRAINT deliverable_project_id_match FOREIGN KEY (project_id) REFERENCES project (id);
 ALTER TABLE deliverable_file ADD CONSTRAINT deliverable_case_id_match FOREIGN KEY (case_id) REFERENCES donor_case (id);
 ALTER TABLE changelog ADD CONSTRAINT changelog_case_id_match FOREIGN KEY (case_id) REFERENCES donor_case (id);
 ALTER TABLE changelog ADD CONSTRAINT changelog_qcable_id_match FOREIGN KEY (qcable_id) REFERENCES qcable (id);
-ALTER TABLE project_info_item ADD CONSTRAINT project_info_item_project_id_match FOREIGN KEY (project_id) REFERENCES project (id);
+ALTER TABLE project_info_item ADD CONSTRAINT project_info_item_project_id_match FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE;
 ALTER TABLE qcable ADD CONSTRAINT qcable_parent_id_match FOREIGN KEY (parent_id) REFERENCES qcable (id);


### PR DESCRIPTION
Do not add cascade delete on deliverable_file or changelog until a method has been developed to handle this data.