### PR TITLE
Allow duplicate names for donor cases

### DIFF
--- a/sampuru-server/src/db/V1__create_schema.sql
+++ b/sampuru-server/src/db/V1__create_schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE project (
 CREATE TABLE donor_case (
     id text PRIMARY KEY,
     project_id text NOT NULL,
-    name text UNIQUE NOT NULL);
+    name text NOT NULL);
  
 CREATE TABLE qcable (
     id text PRIMARY KEY,


### PR DESCRIPTION
Some older projects have duplicate external names but are from unique identities.

This should be merged only after stable ids PR is merged.