### PR TITLE
Remove constraint on oicr_alias being unique

### DIFF
--- a/sampuru-server/src/db/V1__create_schema.sql
+++ b/sampuru-server/src/db/V1__create_schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE qcable (
     qcable_type text NOT NULL,
     project_id text NOT NULL,
     case_id text NOT NULL,
-    oicr_alias text UNIQUE NOT NULL,
+    oicr_alias text NOT NULL,
     status text NOT NULL,
     failure_reason text,
     library_design text,


### PR DESCRIPTION
Low depth and full depth qcables have the same oicr alias as library preparation.