### PR TITLE
Set X-Remote-User header for webpack proxy

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,10 @@ module.exports = {
       '/api': {
         target: 'http://localhost:8088',
         secure: false,
-        changeOrigin: true
+        changeOrigin: true,
+        onProxyReq: function (proxyReq, req, res) {
+          proxyReq.setHeader('X-Remote-User', 'amosquera');
+        }
       }
     },
     headers: {


### PR DESCRIPTION
This is to avoid the NPE when the webpack dev server is talking to the Undertow server