### PR TITLE
TypeScript 4.3 introduces stricter type-checking, add function that acts as a type guard

### DIFF
--- a/sampuru-ui/src/sankey.ts
+++ b/sampuru-ui/src/sankey.ts
@@ -153,6 +153,7 @@ export function drawSankey(sankey: SankeyTransition) {
     return (d.includes("Pending") ? "Pending": (d.includes("Failed") ? "Failed" : d));
   }
 
+  // This acts as a type guard -> performs a runtime check guareenting that type is Node in this scope
   const getNodeName = function(node: Node) {
     return node.name;
   }


### PR DESCRIPTION
Newer versions of TypeScript were resulting in a compilation error "Property 'name' does not exist on type 'never'". 