### PR TITLE
[GR-1356] WIP: updated DB schema for v2 cases

### DIFF
--- a/sampuru-server/src/db/V1__create_schema.sql
+++ b/sampuru-server/src/db/V1__create_schema.sql
@@ -8,67 +8,135 @@ CREATE TABLE project (
     kits text[],
     reference_genome text,
     created_date timestamp,
-    completion_date timestamp);
+    completion_date timestamp
+);
+
+CREATE TABLE donor (
+    id text PRIMARY KEY,
+    oicr_alias text,
+    external_name text
+);
+
+CREATE TABLE qcable (
+    id text PRIMARY KEY,
+    oicr_alias text,
+    status text NOT NULL,
+    failure_reason text
+);
  
 CREATE TABLE donor_case (
     id text PRIMARY KEY,
-    project_id text NOT NULL,
-    name text NOT NULL);
- 
-CREATE TABLE qcable (
-    id text PRIMARY KEY,
-    qcable_type text NOT NULL,
-    project_id text NOT NULL,
-    case_id text NOT NULL,
-    oicr_alias text NOT NULL,
-    external_name text,
-    status text NOT NULL,
-    failure_reason text,
-    library_design text,
-    parent_id text);
+    donor_id text NOT NULL,
+    assay_name text NOT NULL,
+    tissue_origin text NOT NULL,
+    tissue_type text NOT NULL,
+    timepoint text,
+    receipt_qcable_id text,
+    informatics_qcable_id text,
+    draft_report_qcable_id text,
+    final_report_qcable_id text,
+    CONSTRAINT donor_case_donor_id_match FOREIGN KEY (donor_id) REFERENCES donor (id),
+    CONSTRAINT donor_case_unique
+        UNIQUE (donor_id, assay_name, tissue_origin, tissue_type, timepoint),
+    CONSTRAINT donor_case_receipt_match FOREIGN KEY (receipt_qcable_id) REFERENCES qcable (id),
+    CONSTRAINT donor_case_informatics_match FOREIGN KEY (informatics_qcable_id)
+        REFERENCES qcable (id),
+    CONSTRAINT donor_case_draft_report_match FOREIGN KEY (draft_report_qcable_id)
+        REFERENCES qcable (id),
+    CONSTRAINT donor_case_final_report_match FOREIGN KEY (final_report_qcable_id)
+        REFERENCES qcable (id)
+);
 
--- If the writes can be condensed into one transaction, consider changing case_id to its own table (case_id, deliverable_id)
--- see https://www.postgresql.org/docs/current/arrays.html "searching for specific array elements can be a sign of
--- database misdesign"
+CREATE TABLE case_project (
+    case_id text NOT NULL,
+    project_id text NOT NULL,
+    PRIMARY KEY (case_id, project_id),
+    CONSTRAINT case_project_case_match FOREIGN KEY (case_id) REFERENCES donor_case (id)
+        ON DELETE CASCADE,
+    CONSTRAINT case_project_project_match FOREIGN KEY (project_id) REFERENCES project (id)
+);
+
+CREATE TABLE case_test (
+    id SERIAL PRIMARY KEY,
+    case_id text NOT NULL,
+    name text NOT NULL,
+    tissue_origin text,
+    tissue_type text,
+    timepoint text,
+    group_id text,
+    extraction_qcable_id text,
+    library_preparation_qcable_id text,
+    library_qualification_qcable_id text,
+    full_depth_qcable_id text,
+    CONSTRAINT case_test_case_match FOREIGN KEY (case_id) REFERENCES donor_case (id)
+        ON DELETE CASCADE,
+    CONSTRAINT case_test_unique
+        UNIQUE (case_id, name, tissue_origin, tissue_type, timepoint, group_id),
+    CONSTRAINT donor_case_extraction_match FOREIGN KEY (extraction_qcable_id)
+        REFERENCES qcable (id),
+    CONSTRAINT donor_case_library_preparation_match FOREIGN KEY (library_preparation_qcable_id)
+        REFERENCES qcable (id),
+    CONSTRAINT donor_case_library_qualification_match FOREIGN KEY (library_qualification_qcable_id)
+        REFERENCES qcable (id),
+    CONSTRAINT donor_case_full_depth_match FOREIGN KEY (full_depth_qcable_id)
+        REFERENCES qcable (id)
+);
+
 CREATE TABLE deliverable_file (
     id SERIAL PRIMARY KEY,
     project_id text NOT NULL,
     location text NOT NULL,
     notes text,
-    expiry_date timestamp);
- 
+    expiry_date timestamp
+);
+-- No foreign key on project_id due to reload procedure deleting projects
+
+CREATE TABLE donor_deliverable (
+    deliverable_id int NOT NULL,
+    donor_id text NOT NULL,
+    PRIMARY KEY (deliverable_id, donor_id),
+    CONSTRAINT deliverable_id_match FOREIGN KEY (deliverable_id) REFERENCES deliverable_file (id)
+        ON DELETE CASCADE
+);
+-- No foreign key on donor_id due to reload procedure deleting donors
+
 CREATE TABLE changelog (
     id SERIAL PRIMARY KEY,
-    project_id text NOT NULL,
-    qcable_id text,
-    case_id text NOT NULL,
     change_date timestamp NOT NULL,
-    content text NOT NULL);
- 
-CREATE TABLE notification (
-    id SERIAL PRIMARY KEY,
-    user_id text NOT NULL,
-    issue_date timestamp NOT NULL,
-    resolved_date timestamp,
-    content text NOT NULL);
- 
+    content text NOT NULL
+);
+
+CREATE TABLE project_changelog(
+    project_id text NOT NULL,
+    changelog_id integer NOT NULL,
+    PRIMARY KEY (project_id, changelog_id),
+    CONSTRAINT project_changelog_changelog_match FOREIGN KEY (changelog_id)
+        REFERENCES changelog (id) ON DELETE CASCADE
+);
+-- No foreign key on project_id due to reload procedure deleting projects
+
+CREATE TABLE donor_case_changelog(
+    case_id text NOT NULL,
+    changelog_id integer NOT NULL,
+    PRIMARY KEY (case_id, changelog_id),
+    CONSTRAINT donor_case_changelog_changelog_match FOREIGN KEY (changelog_id)
+        REFERENCES changelog (id) ON DELETE CASCADE
+);
+-- No foreign key on case_id due to reload procedure deleting donor_cases
+
 CREATE TABLE project_info_item (
     id SERIAL PRIMARY KEY,
     project_id text NOT NULL,
     type text NOT NULL,
     content text,
     expected integer,
-    received integer);
- 
-ALTER TABLE donor_case ADD CONSTRAINT case_project_id_match FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE;
-ALTER TABLE qcable ADD CONSTRAINT qcable_project_id_match FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE;
-ALTER TABLE qcable ADD CONSTRAINT qcable_case_id_match FOREIGN KEY (case_id) REFERENCES donor_case (id) ON DELETE CASCADE;
-ALTER TABLE deliverable_file ADD CONSTRAINT deliverable_project_id_match FOREIGN KEY (project_id) REFERENCES project (id);
-ALTER TABLE project_info_item ADD CONSTRAINT project_info_item_project_id_match FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE;
-ALTER TABLE qcable ADD CONSTRAINT qcable_parent_id_match FOREIGN KEY (parent_id) REFERENCES qcable (id);
+    received integer,
+    CONSTRAINT project_info_item_project_id_match FOREIGN KEY (project_id) REFERENCES project (id)
+        ON DELETE CASCADE
+);
 
-CREATE INDEX ON qcable(id);
-CREATE INDEX ON qcable(project_id);
-CREATE INDEX ON qcable(case_id);
-CREATE INDEX ON qcable(parent_id);
-CREATE INDEX ON donor_case(project_id);
+-- give user a project called "ADMINISTRATOR" to give them admin privileges
+CREATE TABLE user_access (
+    username text,
+    project text
+);

--- a/sampuru-server/src/db/V1__create_schema.sql
+++ b/sampuru-server/src/db/V1__create_schema.sql
@@ -64,14 +64,15 @@ CREATE TABLE case_test (
     tissue_type text,
     timepoint text,
     group_id text,
+    targeted_sequencing text,
     extraction_qcable_id text,
     library_preparation_qcable_id text,
     library_qualification_qcable_id text,
     full_depth_qcable_id text,
     CONSTRAINT case_test_case_match FOREIGN KEY (case_id) REFERENCES donor_case (id)
         ON DELETE CASCADE,
-    CONSTRAINT case_test_unique
-        UNIQUE (case_id, name, tissue_origin, tissue_type, timepoint, group_id),
+    CONSTRAINT case_test_unique UNIQUE (case_id, name, tissue_origin, tissue_type, timepoint,
+        group_id, targeted_sequencing),
     CONSTRAINT donor_case_extraction_match FOREIGN KEY (extraction_qcable_id)
         REFERENCES qcable (id),
     CONSTRAINT donor_case_library_preparation_match FOREIGN KEY (library_preparation_qcable_id)

--- a/sampuru-server/src/db/V2__qcable_table_view.sql
+++ b/sampuru-server/src/db/V2__qcable_table_view.sql
@@ -1,3 +1,4 @@
+-- TODO: update or remove
 CREATE OR REPLACE VIEW qcable_table AS
 SELECT
 receipt_inspection_qcable.project_id       AS project_id,

--- a/sampuru-server/src/db/V3__case_card_view.sql
+++ b/sampuru-server/src/db/V3__case_card_view.sql
@@ -1,3 +1,4 @@
+-- TODO: update or remove
 CREATE OR REPLACE VIEW case_card AS
 SELECT
 case_id,

--- a/sampuru-server/src/db/V4__sankey_transitions_view.sql
+++ b/sampuru-server/src/db/V4__sankey_transitions_view.sql
@@ -1,3 +1,4 @@
+-- TODO: update or remove
 CREATE OR REPLACE VIEW sankey_transition AS
 SELECT
 project_id,

--- a/sampuru-server/src/db/V5__user_table.sql
+++ b/sampuru-server/src/db/V5__user_table.sql
@@ -1,4 +1,0 @@
--- give user a project called "ADMINISTRATOR" to give them admin privileges
-CREATE TABLE user_access (
-    username text,
-    project text);

--- a/sampuru-server/src/db/V6__deliverable_case_table.sql
+++ b/sampuru-server/src/db/V6__deliverable_case_table.sql
@@ -1,7 +1,0 @@
-CREATE TABLE deliverable_case (
-    deliverable_id int NOT NULL,
-    case_id text NOT NULL
-);
-
-ALTER TABLE deliverable_case ADD CONSTRAINT deliverable_id_match FOREIGN KEY (deliverable_id) REFERENCES deliverable_file (id);
-ALTER TABLE deliverable_case ADD CONSTRAINT case_id_match FOREIGN KEY (case_id) REFERENCES donor_case (id);

--- a/sampuru-server/src/db/V7__cases_per_qc_gate_view.sql
+++ b/sampuru-server/src/db/V7__cases_per_qc_gate_view.sql
@@ -1,3 +1,4 @@
+-- TODO: update or remove
 CREATE OR REPLACE VIEW cases_per_quality_gate AS
 SELECT project_id,
        COUNT(DISTINCT (CASE WHEN receipt_inspection_qcable_alias IS NOT NULL AND receipt_inspection_qcable_status = 'passed' AND case_id NOT IN (SELECT DISTINCT case_id FROM qcable WHERE qcable_type = 'receipt_inspection' AND status IN ('failed', 'pending')) THEN case_id END)) AS receipt_inspection_completed_cases, /*We only care about failed and pending cases at this gate*/


### PR DESCRIPTION
I just wanted to make this available and keep it in view. Much work is needed on Sampuru to support the database changes and new idea of cases, and that work should be done on top of this branch.

Moving to this new schema will require a complete wipe of the existing database with the exception of users and deliverables. There is no useful way to transform the current cases into the desired ones.

I have only written the table definitions thus far. I've left the views unmodified, with notes that they need updated or removed, as I'm not sure whether similar views will even still be useful in the application.